### PR TITLE
deps: bump pinmame-dotnet

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -172,14 +172,10 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			// lamps
-			var changedLamps = _pinMame.GetChangedLamps();
-			for (var i = 0; i < changedLamps.Length; i += 2) {
-				var internalId = changedLamps[i];
-				var val = changedLamps[i + 1];
-
-				if (_lamps.ContainsKey(internalId)) {
-					//Logger.Info($"[PinMAME] <= lamp {id}: {val}");
-					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[internalId].Id, val));
+			foreach (var changedLamp in _pinMame.GetChangedLamps()) {
+				if (_lamps.ContainsKey(changedLamp.Id)) {
+					//Logger.Info($"[PinMAME] <= lamp {changedLamp.Id}: {changedLamp.Value}");
+					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[changedLamp.Id].Id, changedLamp.Value));
 				}
 			}
 		}

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.1.0-preview.40" />
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.268" />
-    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.48" />
+    <PackageReference Include="PinMame" Version="0.1.0-preview.41" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.280" />
+    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.55" />
   </ItemGroup>
 
   <Target Name="PluginsDeploy" AfterTargets="Build">


### PR DESCRIPTION
This PR bumps pinmame-dotnet to the latest which replaced `Span<int>` with `PinMameLampInfo[]`.