### PR TITLE
gle: added solenoid startup delay and mech disable settings

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
@@ -45,9 +45,15 @@ namespace VisualPinball.Engine.PinMAME.Editor
 
 		private PinMameRom Rom => _gle.Game.Roms[_selectedRomIndex];
 
+		private bool _toggleStartup = true;
+
+		private SerializedProperty _disableMechsProperty;
+		private SerializedProperty _solenoidDelayProperty;
+
 		private void OnEnable()
 		{
 			_gle = (PinMameGamelogicEngine) target;
+
 			_games = new PinMameGame[] {
 				new AttackFromMars(),
 				new CreatureFromTheBlackLagoon(),
@@ -82,6 +88,9 @@ namespace VisualPinball.Engine.PinMAME.Editor
 					}
 				}
 			}
+
+			_solenoidDelayProperty = serializedObject.FindProperty(nameof(_gle.SolenoidDelay));
+			_disableMechsProperty = serializedObject.FindProperty(nameof(_gle.DisableMechs));
 		}
 
 		public override void OnInspectorGUI()
@@ -117,6 +126,45 @@ namespace VisualPinball.Engine.PinMAME.Editor
 			EditorGUILayout.LabelField("ROM ID", _gle.romId);
 
 			EditorGUI.EndDisabledGroup();
+
+			GUILayout.BeginVertical();
+
+			if (_toggleStartup = EditorGUILayout.BeginFoldoutHeaderGroup(_toggleStartup, "Startup"))
+			{
+				EditorGUI.indentLevel++;
+
+				EditorGUI.BeginChangeCheck();
+
+				EditorGUILayout.PropertyField(_disableMechsProperty, new GUIContent("Disable Mechs"));
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					serializedObject.ApplyModifiedProperties();
+				}
+
+				EditorGUI.BeginChangeCheck();
+
+				var cellRect = EditorGUILayout.GetControlRect();
+
+				var labelRect = cellRect;
+				labelRect.x += labelRect.width - 20;
+				labelRect.width = 20;
+
+				var fieldRect = cellRect;
+				fieldRect.width -= 25;
+
+				EditorGUI.PropertyField(fieldRect, _solenoidDelayProperty, new GUIContent("Solenoid Delay"));
+				GUI.Label(labelRect, "ms");
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					serializedObject.ApplyModifiedProperties();
+				}
+
+				EditorGUI.indentLevel--;
+			}
+
+			GUILayout.EndVertical();
 
 			EditorGUILayout.Space();
 			EditorGUILayout.Separator();

--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
@@ -50,6 +50,10 @@ namespace VisualPinball.Engine.PinMAME.Editor
 		private SerializedProperty _disableMechsProperty;
 		private SerializedProperty _solenoidDelayProperty;
 
+		private bool _toggleDebug = true;
+
+		private SerializedProperty _disableAudioProperty;
+
 		private void OnEnable()
 		{
 			_gle = (PinMameGamelogicEngine) target;
@@ -91,6 +95,7 @@ namespace VisualPinball.Engine.PinMAME.Editor
 
 			_solenoidDelayProperty = serializedObject.FindProperty(nameof(_gle.SolenoidDelay));
 			_disableMechsProperty = serializedObject.FindProperty(nameof(_gle.DisableMechs));
+			_disableAudioProperty = serializedObject.FindProperty(nameof(_gle.DisableAudio));
 		}
 
 		public override void OnInspectorGUI()
@@ -163,6 +168,26 @@ namespace VisualPinball.Engine.PinMAME.Editor
 
 				EditorGUI.indentLevel--;
 			}
+
+			EditorGUILayout.EndFoldoutHeaderGroup();
+
+			if (_toggleDebug = EditorGUILayout.BeginFoldoutHeaderGroup(_toggleStartup, "Debug"))
+			{
+				EditorGUI.indentLevel++;
+
+				EditorGUI.BeginChangeCheck();
+
+				EditorGUILayout.PropertyField(_disableAudioProperty, new GUIContent("Disable Audio"));
+
+				if (EditorGUI.EndChangeCheck())
+				{
+					serializedObject.ApplyModifiedProperties();
+				}
+
+				EditorGUI.indentLevel--;
+			}
+
+			EditorGUILayout.EndFoldoutHeaderGroup();
 
 			GUILayout.EndVertical();
 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -53,7 +53,10 @@ namespace VisualPinball.Engine.PinMAME
 		[Min(0f)]
 		[Tooltip("Delay after startup to listen for solenoid events.")]
 		public float SolenoidDelay = 0;
-	
+
+		[Tooltip("Disable audio")]
+		public bool DisableAudio = false;
+
 		public GamelogicEngineSwitch[] AvailableSwitches {
 			get {
 				UpdateCaches();
@@ -138,14 +141,18 @@ namespace VisualPinball.Engine.PinMAME
 			_pinMame = PinMame.PinMame.Instance(AudioSettings.outputSampleRate);
 
 			_pinMame.SetHandleKeyboard(false);
-			_pinMame.SetHandleMechanics(false);
+			_pinMame.SetHandleMechanics(DisableMechs ? 0 : 1);
 
 			_pinMame.OnGameStarted += OnGameStarted;
 			_pinMame.OnGameEnded += OnGameEnded;
 			_pinMame.OnDisplayAvailable += OnDisplayAvailable;
 			_pinMame.OnDisplayUpdated += OnDisplayUpdated;
-			_pinMame.OnAudioAvailable += OnAudioAvailable;
-			_pinMame.OnAudioUpdated += OnAudioUpdated;
+
+			if (!DisableAudio) {
+				_pinMame.OnAudioAvailable += OnAudioAvailable;
+				_pinMame.OnAudioUpdated += OnAudioUpdated;
+			}
+
 			_pinMame.OnMechAvailable += OnMechAvailable;
 			_pinMame.OnMechUpdated += OnMechUpdated;
 			_pinMame.OnSolenoidUpdated += OnSolenoidUpdated;
@@ -165,16 +172,6 @@ namespace VisualPinball.Engine.PinMAME
 		{
 			Logger.Info($"[PinMAME] Game started.");
 			_isRunning = true;
-
-			if (DisableMechs)
-			{
-				for (int id = 0; id < 10; id++)
-				{
-					Logger.Info($"Disabling mech {id}");
-
-					_pinMame.SetMech(id, null);
-				}
-			}
 
 			SendInitialSwitches();
 
@@ -499,8 +496,13 @@ namespace VisualPinball.Engine.PinMAME
 				_pinMame.OnGameEnded -= OnGameEnded;
 				_pinMame.OnDisplayAvailable -= OnDisplayAvailable;
 				_pinMame.OnDisplayUpdated -= OnDisplayUpdated;
-				_pinMame.OnAudioAvailable -= OnAudioAvailable;
-				_pinMame.OnAudioUpdated -= OnAudioUpdated;
+
+				if (!DisableAudio)
+				{
+					_pinMame.OnAudioAvailable -= OnAudioAvailable;
+					_pinMame.OnAudioUpdated -= OnAudioUpdated;
+				}
+
 				_pinMame.OnMechAvailable -= OnMechAvailable;
 				_pinMame.OnMechUpdated -= OnMechUpdated;
 				_pinMame.OnSolenoidUpdated -= OnSolenoidUpdated;

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.1.0-preview.43" />
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.303" />
+    <PackageReference Include="PinMame" Version="0.1.0-preview.44" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.307" />
     <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.70" />
   </ItemGroup>
 


### PR DESCRIPTION
The PR adds the following options to the PinMAME game logic engine:

- Disable mechs
- Solenoid startup delay

Disable mechs will set all pinmame mechs to null, basically disabling any built in mech, such as the gun motor on T2.

Note, there is no `getMaxMechs` exposed by `Pinmame-dotnet`, so currently we have it hardcoded to `10`. The next time I update `pinmame-dotnet`, I will add this.

The Solenoid startup delay will disable any `OnSolenoid` messages from being delivered until the delay has passed. We have noticed that System 80 games, the outhole coil is fired for a 65ms within the first 200ms after pinmame starts. This is causing the ball to automatically be in the shooter lane on startup.

A couple things about this approach:

- even with 100ms delay, we're missing the `GameOn` coil. 
- I don't like the use of `DateTimeOffset.Now.ToUnixTimeMilliseconds()`. There has to be a unity way to do this. Since this occurs as a callback from C to C# and is happening in a thread, we don't have access to `Time.delta` 