### PR TITLE
misc: bump to latest pinmame. fix disable mechs. update audio to use AudioFormatFloat

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMameGamelogicEngineInspector.cs
@@ -220,7 +220,7 @@ namespace VisualPinball.Engine.PinMAME.Editor
 		private void CreateDisplays(IEnumerable<DisplayComponent> sceneDisplays)
 		{
 			// retrieve layouts from pinmame
-			var pinMame = PinMame.PinMame.Instance(AudioSettings.outputSampleRate);
+			var pinMame = PinMame.PinMame.Instance(PinMameAudioFormat.AudioFormatFloat, AudioSettings.outputSampleRate);
 			var displayLayouts = pinMame.GetAvailableDisplays(_gle.romId);
 
 			// retrieve already existing displays from scene

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -138,10 +138,10 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			Logger.Info($"New PinMAME instance at {(double)AudioSettings.outputSampleRate / 1000}kHz");
-			_pinMame = PinMame.PinMame.Instance(AudioSettings.outputSampleRate);
+			_pinMame = PinMame.PinMame.Instance(PinMameAudioFormat.AudioFormatFloat, AudioSettings.outputSampleRate);
 
 			_pinMame.SetHandleKeyboard(false);
-			_pinMame.SetHandleMechanics(DisableMechs ? 0 : 1);
+			_pinMame.SetHandleMechanics(DisableMechs ? 0 : 0xFF);
 
 			_pinMame.OnGameStarted += OnGameStarted;
 			_pinMame.OnGameEnded += OnGameEnded;
@@ -304,18 +304,18 @@ namespace VisualPinball.Engine.PinMAME
 			if (_audioFilterChannels == _audioInfo.Channels) { // n channels -> n channels
 				frame = new float[frameSize];
 				unsafe {
-					var src = (short*)framePtr;
+					var src = (float*)framePtr;
 					for (var i = 0; i < frameSize; i++) {
-						frame[i] = src[i] / 32768f;
+						frame[i] = src[i];
 					}
 				}
 
 			} else if (_audioFilterChannels > _audioInfo.Channels) { // 1 channel -> 2 channels
 				frame = new float[frameSize * 2];
 				unsafe {
-					var src = (short*)framePtr;
+					var src = (float*)framePtr;
 					for (var i = 0; i < frameSize; i++) {
-						frame[i * 2] = src[i] / 32768f;
+						frame[i * 2] = src[i];
 						frame[i * 2 + 1] = frame[i * 2];
 					}
 				}
@@ -323,9 +323,9 @@ namespace VisualPinball.Engine.PinMAME
 			} else { // 2 channels -> 1 channel
 				frame = new float[frameSize / 2];
 				unsafe {
-					var src = (short*)framePtr;
+					var src = (float*)framePtr;
 					for (var i = 0; i < frameSize; i += 2) {
-						frame[i] = src[i] / 32768f;
+						frame[i] = src[i];
 					}
 				}
 			}

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.1.0-preview.44" />
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.307" />
-    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.70" />
+    <PackageReference Include="PinMame" Version="0.1.0-preview.45" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.311" />
+    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.71" />
   </ItemGroup>
 
   <Target Name="PluginsDeploy" AfterTargets="Build">


### PR DESCRIPTION
`g_fHandleMechanics` in `libpinmame` is used as a bitmask instead of a int toggle.

To disable all built in mechanics, we should use `_pinMame.SetHandleMechanics(0)`. To enable all mechs, we need to set `_pinMame.SetHandleMechanics(0xFF)`. This will enable up to 16 mechs. No games are using that many built in mechs.

This update also adds support to receive audio in `float` array's instead of `int16` 