### PR TITLE
Misc updates: Rock lamps, coils and slings; PinMame Native + VPE deps

### DIFF
--- a/VisualPinball.Engine.PinMAME/Games/Rock.cs
+++ b/VisualPinball.Engine.PinMAME/Games/Rock.cs
@@ -19,7 +19,6 @@
 using System;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Engine.PinMAME.MPUs;
-using VisualPinball.Engine.Common;
 
 namespace VisualPinball.Engine.PinMAME.Games
 {
@@ -71,7 +70,7 @@ namespace VisualPinball.Engine.PinMAME.Games
 		};
 
 		public override GamelogicEngineLamp[] AvailableLamps { get; } = {
-			new GamelogicEngineLamp("01") { Description = "Lamp 1", Type = LampType.SingleOffOn, DeviceHint = "^LampGroup1$" },
+			new GamelogicEngineLamp("01") { Description = "Lamp 1" },
 			new GamelogicEngineLamp("03") { Description = "Shoot Again" },
 			new GamelogicEngineLamp("05") { Description = "#1 Drop Target (Upper)" },
 			new GamelogicEngineLamp("06") { Description = "#2 Drop Target (Upper)" },
@@ -80,8 +79,8 @@ namespace VisualPinball.Engine.PinMAME.Games
 			new GamelogicEngineLamp("09") { Description = "Level 1" },
 			new GamelogicEngineLamp("10") { Description = "Level 2" },
 			new GamelogicEngineLamp("11") { Description = "Level 3" },
-			new GamelogicEngineLamp("12") { Description = "Lamp 12", DeviceHint = "^(L12|LampGroup12)$", NumMatches = 2 },
-			new GamelogicEngineLamp("13") { Description = "Lamp 13", DeviceHint = "^(L13[a-b]|LampGroup13)$", NumMatches = 3  },
+			new GamelogicEngineLamp("12") { Description = "Lamp 12" },
+			new GamelogicEngineLamp("13") { Description = "Lamp 13", DeviceHint = "^L13[a-b]$", NumMatches = 2  },
 			new GamelogicEngineLamp("14") { Description = "#1 Drop Target (Lower)" },
 			new GamelogicEngineLamp("15") { Description = "#2 Drop Target (Lower)" },
 			new GamelogicEngineLamp("16") { Description = "#3 Drop Target (Lower)" },
@@ -124,12 +123,10 @@ namespace VisualPinball.Engine.PinMAME.Games
 			new GamelogicEngineCoil("06", 6) { Description = "Four Pos. Bank Reset", DeviceHint = "^4PosBank\\s*" },
 			new GamelogicEngineCoil("08", 8) { Description = "Knocker Assembly" },
 			new GamelogicEngineCoil("09", 9) { Description = "Outhole", DeviceHint = "^Trough\\s*\\d?", DeviceItemHint = "eject_coil" },
-
-			new GamelogicEngineCoil(CoilFlipperLowerRight, 46) { Description = "Right Flippers", DeviceHint = "^(Upper|Lower)RightFlipper$", NumMatches = 2 },
-			new GamelogicEngineCoil(CoilFlipperLowerLeft, 48) { Description = "Left Flippers", DeviceHint = "^(Upper|Lower)LeftFlipper$",  NumMatches = 2 },
-
-			new GamelogicEngineCoil(CoilFlipperUpperRight, 34) { IsUnused = true },
-			new GamelogicEngineCoil(CoilFlipperUpperLeft, 36) { IsUnused = true },
+			new GamelogicEngineCoil(CoilFlipperUpperRight, 45) { Description = "Upper Right Flipper", DeviceHint = "^UpperRightFlipper$" },
+			new GamelogicEngineCoil(CoilFlipperLowerRight, 46) { Description = "Lower Right Flipper", DeviceHint = "^LowerRightFlipper$" },
+			new GamelogicEngineCoil(CoilFlipperUpperLeft, 47) { Description = "Upper Left Flipper", DeviceHint = "^UpperLeftFlipper$" },
+			new GamelogicEngineCoil(CoilFlipperLowerLeft, 48) { Description = "Lower Left Flipper", DeviceHint = "^LowerLeftFlipper$" },
 		};
 	}
 }

--- a/VisualPinball.Engine.PinMAME/Games/Rock.cs
+++ b/VisualPinball.Engine.PinMAME/Games/Rock.cs
@@ -41,7 +41,7 @@ namespace VisualPinball.Engine.PinMAME.Games
 
 		protected override GamelogicEngineSwitch[] Switches { get; } = {
 			new GamelogicEngineSwitch("40") { Description = "#1 Drop Target (Upper)" },
-			new GamelogicEngineSwitch("41") { Description = "10 Point (2)", DeviceHint = "^sw41[a-f]$", NumMatches = 6 },
+			new GamelogicEngineSwitch("41") { Description = "10 Point (2)", DeviceHint = "^(sw41[a-f]|(Left|Right)\\sSlingshot)$", NumMatches = 8 },
 			new GamelogicEngineSwitch("42") { Description = "Right Flipper (Lower)", DeviceHint = "^LowerRightFlipper$" },
 			new GamelogicEngineSwitch("43") { Description = "Rollunder" },
 			new GamelogicEngineSwitch("44") { Description = "Right Outside Rollover" },

--- a/VisualPinball.Engine.PinMAME/PinMameGame.cs
+++ b/VisualPinball.Engine.PinMAME/PinMameGame.cs
@@ -98,7 +98,13 @@ namespace VisualPinball.Engine.PinMAME
 
 		protected GamelogicEngineCoil[] Concat(IEnumerable<GamelogicEngineCoil> parent, IEnumerable<GamelogicEngineCoil> children)
 		{
-			var c = parent.ToDictionary(s => s.InternalId, s => s);
+			var ids = parent.ToDictionary(s => s.Id, s => s);
+			foreach (var child in children) {
+				if (ids.ContainsKey(child.Id)) {
+					ids.Remove(child.Id);
+				}
+			}
+			var c = ids.Values.ToDictionary(s => s.InternalId, s => s);
 			foreach (var child in children) {
 				c[child.InternalId] = child;
 			}

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="PinMame" Version="0.1.0-preview.47" />
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.322" />
-    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.75" /> 
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.334" />
+    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.80" /> 
     <!-- Uncomment when doing local dev -->
     <!-- 
     <Reference Include="VisualPinball.Engine">


### PR DESCRIPTION
This PR updates the following:

- Rock no longer uses `LampType.SingleOffOn` which was removed in the latest `VisualPinball.Engine`.
- Rock uses coils `45` and `47` for upper flippers
- Adds switches for Rock slingshots
- Allows game definitions to overwrite default coils by `Id` (ie, `CoilFlipperUpperLeft`, `CoilFlipperUpperRight` not all games have same upper flipper coils) 
- Updates `VisualPinball.Engine` to `0.0.1-preview.80`
- Updates `PinMame.Native` to `3.4.0-preview.334`