### PR TITLE
Add support for ios-arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             rid: osx-x64
           - os: macos-latest
             rid: osx-arm64
+          - os: macos-latest
+            rid: ios-arm64
           - os: ubuntu-latest
             rid: linux-x64
     steps:

--- a/README.md
+++ b/README.md
@@ -36,19 +36,22 @@ In order to not accidentally commit those files, we recommend to ignore them:
 ```bash
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/libpinmame.so.3.4.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/libpinmame.so.3.5.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/libpinmame.3.4.dylib.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/libpinmame.3.5.dylib.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-arm64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-arm64/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-arm64/libpinmame.3.4.dylib.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-arm64/libpinmame.3.5.dylib.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/PinMame.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/VisualPinball.Engine.PinMAME.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.dylib.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/libpinmame-3.4.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/libpinmame-3.5.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x64/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x64/libpinmame-3.4.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x64/libpinmame-3.5.dll.meta
 ```
 
 ## License

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 882c18f2501344d79be409d6ab585917
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/PinMame.dll.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/PinMame.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 6a4debbb1ddc4c9cb806ff9d80e8ac00
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/VisualPinball.Engine.PinMAME.dll.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/VisualPinball.Engine.PinMAME.dll.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 966fdccbfadd40c496529b02ab8a9dca
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.dylib.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.dylib.meta
@@ -1,0 +1,70 @@
+fileFormatVersion: 2
+guid: 5cceccb7bb224746b781eb57bff8b70b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: ARM64
+        CompileFlags: 
+        FrameworkDependencies: StoreKit;
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -142,8 +142,15 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			Logger.Info($"New PinMAME instance at {(double)AudioSettings.outputSampleRate / 1000}kHz");
-			_pinMame = PinMame.PinMame.Instance(PinMameAudioFormat.AudioFormatFloat, AudioSettings.outputSampleRate);
 
+			string vpmPath = null;
+
+			#if UNITY_IOS && !UNITY_EDITOR
+			vpmPath = Application.dataPath + "/pinmame";
+			#endif
+
+			_pinMame = PinMame.PinMame.Instance(PinMameAudioFormat.AudioFormatFloat, AudioSettings.outputSampleRate, vpmPath);
+                
 			_pinMame.SetHandleKeyboard(false);
 			_pinMame.SetHandleMechanics(DisableMechs ? 0 : 0xFF);
 

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -13,8 +13,8 @@
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.2.0-preview.2" />
-    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.6" />
+    <PackageReference Include="PinMame" Version="0.2.0-preview.3" />
+    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.9" />
     <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.83" /> 
     <!-- Uncomment when doing local dev -->
     <!-- 
@@ -27,7 +27,7 @@
     <ItemGroup>
       <Plugins Include="$(OutDir)$(AssemblyName).dll" />
       <Plugins Include="$(OutDir)PinMame.dll" />
-      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.6\runtimes\$(RuntimeIdentifier)\native\*" />
+      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.9\runtimes\$(RuntimeIdentifier)\native\*" />
     </ItemGroup>
     <Message Text="PluginsDeploy: @(Plugins)" />
     <Copy SourceFiles="@(Plugins)" DestinationFolder="..\VisualPinball.Engine.PinMAME.Unity\Plugins\$(RuntimeIdentifier)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
This PR adds support for ios-arm64.

The changes include:

- creating a `plugins/ios-arm64` folder
- updating the `vpmPath` to `Assets/pinmame` for `UNITY_IOS`
- updating to PinMame-dotnet and PinMame native libraries

See https://github.com/vpinball/pinmame-dotnet/pull/37 and https://github.com/vpinball/pinmame/pull/55 for additional info