### PR TITLE
misc: add support for android-arm64-v8a

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
             rid: ios-arm64
           - os: ubuntu-latest
             rid: linux-x64
+          - os: ubuntu-latest
+            rid: android-arm64-v8a
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ In order to not accidentally commit those files, we recommend to ignore them:
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/VisualPinball.Engine.PinMAME.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/linux-x64/libpinmame.so.3.5.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/PinMame.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/VisualPinball.Engine.PinMAME.dll.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/libpinmame.3.5.so.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/VisualPinball.Engine.PinMAME.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-x64/libpinmame.3.5.dylib.meta

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bf95cea073454d7e9cd7ff2790c9616
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/PinMame.dll.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/PinMame.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5cceccb7bb224746b781eb57bff8b70b
+guid: 5a7882428e7fe448494ec2f6bca74dce
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -16,34 +16,35 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude iOS: 0
-        Exclude tvOS: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
-        CPU: ARM64
         DefaultValueInitialized: true
-        OS: OSX
   - first:
       Standalone: Linux64
     second:
       enabled: 0
       settings:
         CPU: None
-  - first:
-      Standalone: OSXUniversal
-    second:
-      enabled: 0
-      settings:
-        CPU: ARM64
   - first:
       Standalone: Win
     second:
@@ -57,14 +58,11 @@ PluginImporter:
       settings:
         CPU: None
   - first:
-      iPhone: iOS
+      Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        AddToEmbeddedBinaries: true
-        CPU: ARM64
-        CompileFlags: 
-        FrameworkDependencies: StoreKit;
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/VisualPinball.Engine.PinMAME.dll.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/VisualPinball.Engine.PinMAME.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5cceccb7bb224746b781eb57bff8b70b
+guid: 7983fd79f041f48f9bf2cf604405e971
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -16,34 +16,35 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude iOS: 0
-        Exclude tvOS: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
-        CPU: ARM64
         DefaultValueInitialized: true
-        OS: OSX
   - first:
       Standalone: Linux64
     second:
       enabled: 0
       settings:
         CPU: None
-  - first:
-      Standalone: OSXUniversal
-    second:
-      enabled: 0
-      settings:
-        CPU: ARM64
   - first:
       Standalone: Win
     second:
@@ -57,14 +58,11 @@ PluginImporter:
       settings:
         CPU: None
   - first:
-      iPhone: iOS
+      Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        AddToEmbeddedBinaries: true
-        CPU: ARM64
-        CompileFlags: 
-        FrameworkDependencies: StoreKit;
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/libpinmame.3.5.so.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/android-arm64-v8a/libpinmame.3.5.so.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5cceccb7bb224746b781eb57bff8b70b
+guid: 03d2169aac52497b8633b93fbd6f2e35
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -16,22 +16,32 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
         Exclude Win: 1
         Exclude Win64: 1
-        Exclude iOS: 0
-        Exclude tvOS: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM64
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
-        CPU: ARM64
+        CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: OSX
+        OS: AnyOS
   - first:
       Standalone: Linux64
     second:
@@ -43,7 +53,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: ARM64
+        CPU: None
   - first:
       Standalone: Win
     second:
@@ -57,14 +67,20 @@ PluginImporter:
       settings:
         CPU: None
   - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
       iPhone: iOS
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        AddToEmbeddedBinaries: true
-        CPU: ARM64
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
         CompileFlags: 
-        FrameworkDependencies: StoreKit;
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -13,9 +13,9 @@
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.2.0-preview.3" />
-    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.9" />
-    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.83" /> 
+    <PackageReference Include="PinMame" Version="0.2.0-preview.5" />
+    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.14" />
+    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.87" /> 
     <!-- Uncomment when doing local dev -->
     <!-- 
     <Reference Include="VisualPinball.Engine">
@@ -27,7 +27,7 @@
     <ItemGroup>
       <Plugins Include="$(OutDir)$(AssemblyName).dll" />
       <Plugins Include="$(OutDir)PinMame.dll" />
-      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.9\runtimes\$(RuntimeIdentifier)\native\*" />
+      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.14\runtimes\$(RuntimeIdentifier)\native\*" />
     </ItemGroup>
     <Message Text="PluginsDeploy: @(Plugins)" />
     <Copy SourceFiles="@(Plugins)" DestinationFolder="..\VisualPinball.Engine.PinMAME.Unity\Plugins\$(RuntimeIdentifier)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
This PR adds support for `android-arm64-v8a`.

In addition this updates the `vpmPath` only for iOS and Android.

To include a rom in a build, create a `StreamingAssets` folder under `Assets` and place the zipped rom file. 

When a build is run, it will create a `pinmame/roms` folder in `Application.persistentDataPath` and copy the zip file from `StreamingAssets`.

For more information on why this is done, please refer to: https://docs.unity3d.com/Manual/StreamingAssets.html


Note: this is subject to change once rom handling has been officially architected.
