### PR TITLE
Add new GLE OnStarted event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/o
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/osx-arm64/libpinmame.3.5.dylib.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/VisualPinball.Engine.PinMAME.dll.meta
-git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.dylib.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.a.meta
+git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libz.a.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/PinMame.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/VisualPinball.Engine.PinMAME.dll.meta
 git update-index --assume-unchanged VisualPinball.Engine.PinMAME.Unity/Plugins/win-x86/libpinmame-3.5.dll.meta

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.a.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libpinmame.3.5.a.meta
@@ -25,6 +25,12 @@ PluginImporter:
         Exclude iOS: 0
         Exclude tvOS: 1
   - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
       Editor: Editor
     second:
       enabled: 0
@@ -64,7 +70,7 @@ PluginImporter:
         AddToEmbeddedBinaries: true
         CPU: ARM64
         CompileFlags: 
-        FrameworkDependencies: StoreKit;
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libz.a.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Plugins/ios-arm64/libz.a.meta
@@ -1,0 +1,76 @@
+fileFormatVersion: 2
+guid: 2327fd2f000c4e668f1bfc637dfb8474
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+        Exclude tvOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: ARM64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: true
+        CPU: ARM64
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -153,7 +153,7 @@ namespace VisualPinball.Engine.PinMAME
 				byte[] data = null;
 
 				#if UNITY_IOS
-					data = File.ReadAllBytes(Path.Combine(Application.streamingAssetsPath, $"{romId}.zip");
+					data = File.ReadAllBytes(Path.Combine(Application.streamingAssetsPath, $"{romId}.zip"));
 				#else
 					UnityWebRequest webRequest = new UnityWebRequest(Path.Combine(Application.streamingAssetsPath, $"{romId}.zip"));
 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -36,7 +36,7 @@ namespace VisualPinball.Engine.PinMAME
 	[Serializable]
 	[DisallowMultipleComponent]
 	[RequireComponent(typeof(AudioSource))]
-	[AddComponentMenu("Visual Pinball/Game Logic Engine/PinMAME")]
+	[AddComponentMenu("Visual Pinball/Gamelogic Engine/PinMAME")]
 	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine
 	{
 		public string Name { get; } = "PinMAME Gamelogic Engine";
@@ -87,6 +87,7 @@ namespace VisualPinball.Engine.PinMAME
 		public event EventHandler<LampColorEventArgs> OnLampColorChanged;
 		public event EventHandler<AvailableDisplays> OnDisplaysAvailable;
 		public event EventHandler<DisplayFrameData> OnDisplayFrame;
+		public event EventHandler<EventArgs> OnStarted;
 
 		[NonSerialized] private Player _player;
 		[NonSerialized] private PinMame.PinMame _pinMame;
@@ -214,6 +215,10 @@ namespace VisualPinball.Engine.PinMAME
 			SendMechs();
 
 			_solenoidDelayStart = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+			lock (_dispatchQueue) {
+				_dispatchQueue.Enqueue(() => OnStarted?.Invoke(this, EventArgs.Empty));
+			}
 		}
 
 		private void Update()

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -13,9 +13,9 @@
     <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PinMame" Version="0.2.0-preview.5" />
-    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.14" />
-    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.87" /> 
+    <PackageReference Include="PinMame" Version="0.2.0-preview.6" />
+    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.18" />
+    <PackageReference Include="VisualPinball.Engine" Version="0.0.1-preview.92" /> 
     <!-- Uncomment when doing local dev -->
     <!-- 
     <Reference Include="VisualPinball.Engine">
@@ -28,14 +28,14 @@
        <Plugins Include="$(OutDir)PinMame.dll" />
     </ItemGroup>
     <ItemGroup Condition="'$(RuntimeIdentifier)' == 'ios-arm64'">
-       <Plugins Include="$(NuGetPackageRoot)\pinmame\0.2.0-preview.5\runtimes\ios\lib\netstandard2.1\PinMame.dll" />
+       <Plugins Include="$(NuGetPackageRoot)\pinmame\0.2.0-preview.6\runtimes\ios\lib\netstandard2.1\PinMame.dll" />
     </ItemGroup>
     <ItemGroup Condition="'$(RuntimeIdentifier)' == 'android-arm64-v8a'">
-       <Plugins Include="$(NuGetPackageRoot)\pinmame\0.2.0-preview.5\runtimes\android\lib\netstandard2.1\PinMame.dll" />
+       <Plugins Include="$(NuGetPackageRoot)\pinmame\0.2.0-preview.6\runtimes\android\lib\netstandard2.1\PinMame.dll" />
     </ItemGroup>
     <ItemGroup>
       <Plugins Include="$(OutDir)$(AssemblyName).dll" />
-      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.14\runtimes\$(RuntimeIdentifier)\native\*" />
+      <Plugins Include="$(NuGetPackageRoot)\pinmame.native.$(RuntimeIdentifier)\3.5.0-preview.18\runtimes\$(RuntimeIdentifier)\native\*" />
     </ItemGroup>
     <Message Text="PluginsDeploy: @(Plugins)" />
     <Copy SourceFiles="@(Plugins)" DestinationFolder="..\VisualPinball.Engine.PinMAME.Unity\Plugins\$(RuntimeIdentifier)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
This PR will need to place after https://github.com/freezy/VisualPinball.Engine/pull/373. We will also need to update the VPE dependency before compiling.

This PR adds support for the new `OnStarted` event.

When working on Rock, we need to initialize our Lamp Relay graph. We can only initialize the graph AFTER the rom has actually started.  `OnPlayerStarted` would happen too soon.

In addition this PR includes updates to make iOS builds use a static `libpinmame.a`. We also include a static `libz.a`  This means you can now directly export an iOS project and build it with no configuration changes. 

Thanks to @freezy who mentioned `NoesisGUI`. This library was a good guide for me to see how iOS was done.