### PR TITLE
misc: update to latest gle interface

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -91,7 +91,8 @@ namespace VisualPinball.Engine.PinMAME
 		public event EventHandler<LampEventArgs> OnLampChanged;
 		public event EventHandler<LampsEventArgs> OnLampsChanged;
 		public event EventHandler<RequestedDisplays> OnDisplaysRequested;
-		public event EventHandler<DisplayFrameData> OnDisplayFrame;
+		public event EventHandler<string> OnDisplayClear;
+		public event EventHandler<DisplayFrameData> OnDisplayUpdateFrame;
 		public event EventHandler<EventArgs> OnStarted;
 
 		#endregion
@@ -428,7 +429,7 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			lock (_dispatchQueue) {
-				_dispatchQueue.Enqueue(() => OnDisplayFrame?.Invoke(this,
+				_dispatchQueue.Enqueue(() => OnDisplayUpdateFrame?.Invoke(this,
 					new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
 			}
 		}
@@ -439,7 +440,7 @@ namespace VisualPinball.Engine.PinMAME
 
 			lock (_dispatchQueue) {
 				//Logger.Info($"[PinMAME] Seg data ({index}): {BitConverter.ToString(_frameBuffer[index])}" );
-				_dispatchQueue.Enqueue(() => OnDisplayFrame?.Invoke(this,
+				_dispatchQueue.Enqueue(() => OnDisplayUpdateFrame?.Invoke(this,
 					new DisplayFrameData($"{SegDispPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
 			}
 		}
@@ -493,6 +494,10 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			throw new NotImplementedException($"Still unsupported segmented display format: {layout}.");
+		}
+
+		public void DisplayChanged(DisplayFrameData displayFrameData)
+		{
 		}
 
 		#endregion

--- a/VisualPinball.Engine.PinMAME.Unity/package.json
+++ b/VisualPinball.Engine.PinMAME.Unity/package.json
@@ -10,7 +10,7 @@
   "unity": "2021.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "org.visualpinball.engine.unity": "0.0.1-preview.104"
+    "org.visualpinball.engine.unity": "0.0.1-preview.119"
   },
   "author": "freezy <freezy@vpdb.io>",
   "contributors": [


### PR DESCRIPTION
This PR updates `PinMameGamelogicEngine` to use the latest updates to `IGamelogicEngine`.

Before merging, and after VPE is merged, we should update `package.json` accordingly:

```
  "dependencies": {
    "org.visualpinball.engine.unity": "0.0.1-preview.xxx"
  },
```