### PR TITLE
Support zero-prefixed switch names

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -333,6 +333,7 @@ namespace VisualPinball.Engine.PinMAME
 			_pinMameIdToSwitchIdMappings.Clear();
 			_switchIdToPinMameIdMappings.Clear();
 
+			// check aliases first (the switches/coils that aren't an integer)
 			foreach (var alias in _game.AvailableAliases) {
 				switch (alias.AliasType) {
 					case AliasType.Switch:
@@ -352,16 +353,30 @@ namespace VisualPinball.Engine.PinMAME
 				}
 			}
 
-
+			// retrieve the game's switches
 			foreach (var @switch in _game.AvailableSwitches) {
 				_switches[@switch.Id] = @switch;
 
-				if (int.TryParse(@switch.Id, out int pinMameId)) {
+				if (int.TryParse(@switch.Id, out var pinMameId)) {
 					_pinMameIdToSwitchIdMappings[pinMameId] = @switch.Id;
 					_switchIdToPinMameIdMappings[@switch.Id] = pinMameId;
+
+					// add mappings with prefixed 0.
+					if (pinMameId < 10) {
+						_switchIdToPinMameIdMappings["0" + @switch.Id] = pinMameId;
+						_switchIdToPinMameIdMappings["00" + @switch.Id] = pinMameId;
+
+						_switches["0" + @switch.Id] = @switch;
+						_switches["00" + @switch.Id] = @switch;
+					}
+					if (pinMameId < 100) {
+						_switchIdToPinMameIdMappings["0" + @switch.Id] = pinMameId;
+						_switches["0" + @switch.Id] = @switch;
+					}
 				}
 			}
 
+			// retrieve the game's coils
 			foreach (var coil in _game.AvailableCoils) {
 				_coils[coil.Id] = coil;
 
@@ -371,6 +386,7 @@ namespace VisualPinball.Engine.PinMAME
 				}
 			}
 
+			// retrieve the game's lamps
 			foreach (var lamp in _game.AvailableLamps) {
 				_lamps[lamp.Id] = lamp;
 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -101,7 +101,11 @@ namespace VisualPinball.Engine.PinMAME
 
 		[NonSerialized] private Player _player;
 		[NonSerialized] private PinMame.PinMame _pinMame;
+		[NonSerialized] private BallManager _ballManager;
+		[NonSerialized] private PlayfieldComponent _playfieldComponent;
+
 		[SerializeReference] private PinMameGame _game;
+
 
 		private Dictionary<string, GamelogicEngineSwitch> _switches = new();
 		private Dictionary<int, string> _pinMameIdToSwitchIdMappings = new();
@@ -218,6 +222,8 @@ namespace VisualPinball.Engine.PinMAME
 		public void OnInit(Player player, TableApi tableApi, BallManager ballManager)
 		{
 			string vpmPath = null;
+			_ballManager = ballManager;
+			_playfieldComponent = GetComponentInChildren<PlayfieldComponent>();
 
 			#if (UNITY_IOS || UNITY_ANDROID) && !UNITY_EDITOR
 				vpmPath = Path.Combine(Application.persistentDataPath, "pinmame");
@@ -712,6 +718,10 @@ namespace VisualPinball.Engine.PinMAME
 				}
 				Logger.Info($"[PinMAME] => sw {id}: {isClosed} | {_switches[id].Description}");
 				_pinMame.SetSwitch(_switchIdToPinMameIdMappings[_switches[id].Id], isClosed);
+			} else if (id == "s_spawn_ball") {
+				if (isClosed) {
+					_ballManager.CreateBall(new DebugBallCreator(630, _playfieldComponent.Height / 2f, _playfieldComponent.TableHeight));
+				}
 			} else {
 				Logger.Error($"[PinMAME] Unknown switch \"{id}\".");
 			}


### PR DESCRIPTION
This PR adds support for switch names that are prefixed with `0`. It goes up to 1000, e.g. a switch named `001` will correctly be relayed to PinMAME as `1`, or `099` as `99`. But it won't work for let's say `0001`, in this case we'll do a normal lookup, and print an error if the ROM doesn't have a switch alias named `0001`.

The implementation is somewhat hacky. We just add zero-prefixed references to the lookup tables when registering the strings and keep the rest of the code "simple". We could also have added *another* int-based lookup table that would work for any number. @jsm174 let me know if you prefer the latter.

See also freezy/VisualPinball.Engine#430 for the same feature for coils.

This PR also adds a new `s_spawn_ball` event that adds a ball on the playfield for debugging. 