### PR TITLE
Adapt VPE's threading model with PinMAME 3.7

### DIFF
--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs
@@ -1,0 +1,163 @@
+// Visual Pinball Engine
+// Copyright (C) 2021 freezy and VPE Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#if UNITY_EDITOR
+
+using System;
+using System.Diagnostics;
+using NLog;
+using UnityEditor;
+using UnityEngine;
+using Logger = NLog.Logger;
+
+
+// ReSharper disable CheckNamespace
+
+namespace VisualPinball.Engine.PinMAME.Editor
+{
+	[InitializeOnLoad]
+	public static class PinMamePlayModeLifecycle
+	{
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		private const string LogPrefix = "[PinMAME-debug]";
+		private static bool _stopping;
+		private static Stopwatch _stopwatch;
+		private const int StopTimeoutMs = 2000;
+		private static bool _warnedTimeout;
+		private static System.Threading.Tasks.Task _stopTask;
+
+		private static bool IsDomainReloadDisabled()
+		{
+			// When Enter Play Mode Options are enabled, Unity can skip domain/scene reload.
+			// If domain reload is enabled (default), we must not run PinMAME stop on a background task
+			// that can outlive the managed domain during playmode transitions.
+			try {
+				if (!EditorSettings.enterPlayModeOptionsEnabled) {
+					return false;
+				}
+				return (EditorSettings.enterPlayModeOptions & EnterPlayModeOptions.DisableDomainReload) != 0;
+			} catch {
+				return false;
+			}
+		}
+		// Native stop is potentially blocking; we do it on a background thread.
+
+		static PinMamePlayModeLifecycle()
+		{
+			EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+			EditorApplication.quitting += OnQuitting;
+		}
+
+		private static void OnQuitting()
+		{
+			RequestStop("Editor quitting");
+		}
+
+		private static void OnPlayModeStateChanged(PlayModeStateChange state)
+		{
+			if (state == PlayModeStateChange.ExitingPlayMode) {
+				RequestStop("Exiting play mode");
+			}
+		}
+
+		private static void RequestStop(string reason)
+		{
+			try {
+				if (!PinMame.PinMame.IsRunning) {
+					return;
+				}
+			} catch {
+				return;
+			}
+
+			if (_stopping) {
+				return;
+			}
+
+			_stopping = true;
+			_warnedTimeout = false;
+			_stopwatch = Stopwatch.StartNew();
+			Logger.Warn($"{LogPrefix} [PinMAME] Stop requested ({reason})");
+
+			// Stop sim thread(s) first to avoid starving the PinMAME emulation thread.
+			try {
+				var sims = UnityEngine.Object.FindObjectsByType<VisualPinball.Unity.Simulation.SimulationThreadComponent>(FindObjectsSortMode.None);
+				for (var i = 0; i < sims.Length; i++) {
+					sims[i].StopSimulation();
+				}
+			} catch { }
+
+			// Prefer stopping via the active component(s) so they can unsubscribe callbacks first.
+			try {
+				var engines = UnityEngine.Object.FindObjectsByType<VisualPinball.Engine.PinMAME.PinMameGamelogicEngine>(FindObjectsSortMode.None);
+				for (var i = 0; i < engines.Length; i++) {
+					engines[i].StopForPlayModeExit();
+				}
+			} catch { }
+
+			EditorApplication.update -= Update;
+			EditorApplication.update += Update;
+
+			// Stop PinMAME now.
+			// - With Domain Reload enabled: stop synchronously while the domain is still stable.
+			// - With Domain Reload disabled: stop on a background task to keep the editor responsive.
+			if (IsDomainReloadDisabled()) {
+				_stopTask = System.Threading.Tasks.Task.Run(() => {
+					try {
+						PinMame.PinMame.StopRunningGame();
+					} catch (Exception e) {
+						Logger.Warn(e, $"{LogPrefix} [PinMAME] StopGame failed while exiting play mode.");
+					}
+				});
+			} else {
+				try {
+					PinMame.PinMame.StopRunningGame();
+					_stopTask = System.Threading.Tasks.Task.CompletedTask;
+				} catch (Exception e) {
+					Logger.Warn(e, $"{LogPrefix} [PinMAME] StopGame failed while exiting play mode.");
+					_stopTask = System.Threading.Tasks.Task.CompletedTask;
+				}
+			}
+		}
+
+		private static void Update()
+		{
+			bool running;
+			try {
+				running = PinMame.PinMame.IsRunning;
+			} catch {
+				running = false;
+			}
+
+			var stopDone = _stopTask == null || _stopTask.IsCompleted;
+			if (!running && stopDone) {
+				EditorApplication.update -= Update;
+				_stopping = false;
+				_warnedTimeout = false;
+				_stopTask = null;
+				Logger.Warn($"{LogPrefix} [PinMAME] Stopped (editor)");
+				return;
+			}
+
+			if (!_warnedTimeout && _stopwatch != null && _stopwatch.ElapsedMilliseconds > StopTimeoutMs) {
+				_warnedTimeout = true;
+				Logger.Warn($"{LogPrefix} [PinMAME] Still running after stop timeout (editor)");
+			}
+		}
+	}
+}
+
+#endif

--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs
@@ -92,7 +92,8 @@ namespace VisualPinball.Engine.PinMAME.Editor
 			_stopwatch = Stopwatch.StartNew();
 			Logger.Warn($"{LogPrefix} [PinMAME] Stop requested ({reason})");
 
-			// Stop sim thread(s) first to avoid starving the PinMAME emulation thread.
+			// Stop sim thread(s) first. This reduces the chance of other high-frequency code paths
+			// continuing to call into PinMAME while we are stopping it.
 			try {
 				var sims = UnityEngine.Object.FindObjectsByType<VisualPinball.Unity.Simulation.SimulationThreadComponent>(FindObjectsSortMode.None);
 				for (var i = 0; i < sims.Length; i++) {

--- a/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs.meta
+++ b/VisualPinball.Engine.PinMAME.Unity/Editor/PinMamePlayModeLifecycle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e233609de2ea2164b89f4688b5597e55

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -124,7 +124,7 @@ namespace VisualPinball.Engine.PinMAME
 		private Dictionary<string, GamelogicEngineLamp> _lamps = new();
 		private Dictionary<int, string> _pinMameIdToLampIdMapping = new();
 
-		private bool _isRunning;
+		private volatile bool _isRunning;
 		private int _numMechs;
 		private Dictionary<int, byte[]> _frameBuffer = new();
 		private Dictionary<int, Dictionary<byte, byte>> _dmdLevels = new();

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -19,6 +19,7 @@
 // ReSharper disable PossibleNullReferenceException
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace VisualPinball.Engine.PinMAME
 	[DisallowMultipleComponent]
 	[RequireComponent(typeof(AudioSource))]
 	[AddComponentMenu("Pinball/Gamelogic Engine/PinMAME")]
-	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence
+	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence, IGamelogicCoilOutputFeed, IGamelogicPerformanceStats
 	{
 		public string Name { get; } = "PinMAME Gamelogic Engine";
 		public GamelogicInputDispatchMode SwitchDispatchMode => GamelogicInputDispatchMode.SimulationThread;
@@ -102,7 +103,7 @@ namespace VisualPinball.Engine.PinMAME
 
 		public void SetTimeFence(double timeInSeconds)
 		{
-			if (!_isRunning || _pinMame == null) {
+			if (_pinMame == null) {
 				return;
 			}
 
@@ -112,6 +113,29 @@ namespace VisualPinball.Engine.PinMAME
 			catch (Exception e) {
 				Logger.Warn(e, "[PinMAME] SetTimeFence call failed.");
 			}
+		}
+
+		public bool TryDequeueCoilEvent(out CoilEventArgs coilEvent)
+		{
+			if (_simulationCoilDispatchQueue.TryDequeue(out coilEvent)) {
+				if (Interlocked.Decrement(ref _simulationCoilDispatchQueueSize) < 0) {
+					Interlocked.Exchange(ref _simulationCoilDispatchQueueSize, 0);
+				}
+				return true;
+			}
+
+			return false;
+		}
+
+		public bool TryGetPerformanceStats(out GamelogicPerformanceStats stats)
+		{
+			if (_pinMame == null) {
+				stats = default;
+				return false;
+			}
+
+			stats = new GamelogicPerformanceStats(_isRunning, Volatile.Read(ref _pinMameCallbackRateHz), PinMame.PinMame.RunState);
+			return true;
 		}
 
 		#endregion
@@ -148,6 +172,13 @@ namespace VisualPinball.Engine.PinMAME
 		private static readonly Color Tint = new(1, 0.18f, 0);
 
 		private readonly Queue<Action> _dispatchQueue = new();
+		private readonly ConcurrentQueue<CoilEventArgs> _simulationCoilDispatchQueue = new();
+		private int _simulationCoilDispatchQueueSize;
+		private const int MaxSimulationCoilDispatchQueueSize = 8192;
+		private const double PerfSampleWindowSeconds = 0.25;
+		private long _pinMamePerfWindowStartTicks = Stopwatch.GetTimestamp();
+		private int _pinMameCallbacksInWindow;
+		private float _pinMameCallbackRateHz;
 		private readonly Queue<float[]> _audioQueue = new();
 
 		private int _audioFilterChannels;
@@ -504,6 +535,7 @@ namespace VisualPinball.Engine.PinMAME
 
 				_pinMame.SetHandleKeyboard(false);
 				_pinMame.SetHandleMechanics(DisableMechs ? 0 : 0xFF);
+				SetTimeFence(0.01);
 
 				_pinMame.OnGameStarted += OnGameStarted;
 				_pinMame.OnGameEnded += OnGameEnded;
@@ -585,6 +617,11 @@ namespace VisualPinball.Engine.PinMAME
 				Logger.Info("[PinMAME] Game ended.");
 			}
 			_isRunning = false;
+			while (_simulationCoilDispatchQueue.TryDequeue(out _)) {
+				if (Interlocked.Decrement(ref _simulationCoilDispatchQueueSize) < 0) {
+					Interlocked.Exchange(ref _simulationCoilDispatchQueueSize, 0);
+				}
+			}
 		}
 
 		private void UpdateCaches()
@@ -696,6 +733,8 @@ namespace VisualPinball.Engine.PinMAME
 
 		private void OnDisplayUpdated(int index, IntPtr framePtr, PinMameDisplayLayout displayLayout)
 		{
+			MarkPinMameCallbackActivity();
+
 			if (!_frameBuffer.ContainsKey(index)) {
 				Logger.Warn($"[PinMAME] Dropping display frame for unknown index {index} (layout: {displayLayout}).");
 				return;
@@ -936,6 +975,8 @@ namespace VisualPinball.Engine.PinMAME
 
 		private void OnSolenoidUpdated(int id, bool isActive)
 		{
+			MarkPinMameCallbackActivity();
+
 			if (_pinMameIdToCoilIdMapping.ContainsKey(id)) {
 				if (!_solenoidsEnabled) {
 					_solenoidsEnabled = DateTimeOffset.Now.ToUnixTimeMilliseconds() - _solenoidDelayStart >= SolenoidDelay;
@@ -949,6 +990,16 @@ namespace VisualPinball.Engine.PinMAME
 
 				if (_solenoidsEnabled) {
 					Logger.Info($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
+					if (IsLowLatencySimulationCoil(coil.Id)) {
+						_simulationCoilDispatchQueue.Enqueue(new CoilEventArgs(coil.Id, isActive));
+						if (Interlocked.Increment(ref _simulationCoilDispatchQueueSize) > MaxSimulationCoilDispatchQueueSize) {
+							if (_simulationCoilDispatchQueue.TryDequeue(out _)) {
+								if (Interlocked.Decrement(ref _simulationCoilDispatchQueueSize) < 0) {
+									Interlocked.Exchange(ref _simulationCoilDispatchQueueSize, 0);
+								}
+							}
+						}
+					}
 
 					lock (_dispatchQueue) {
 						_dispatchQueue.Enqueue(() => OnCoilChanged?.Invoke(this, new CoilEventArgs(coil.Id, isActive)));
@@ -1094,6 +1145,32 @@ namespace VisualPinball.Engine.PinMAME
 			}
 
 			return 0;
+		}
+
+		private static bool IsLowLatencySimulationCoil(string coilId)
+		{
+			return !string.IsNullOrEmpty(coilId)
+				&& coilId.StartsWith("c_flipper", StringComparison.OrdinalIgnoreCase);
+		}
+
+		private void MarkPinMameCallbackActivity()
+		{
+			Interlocked.Increment(ref _pinMameCallbacksInWindow);
+
+			var nowTicks = Stopwatch.GetTimestamp();
+			var startTicks = Volatile.Read(ref _pinMamePerfWindowStartTicks);
+			var elapsedSeconds = (double)(nowTicks - startTicks) / Stopwatch.Frequency;
+			if (elapsedSeconds < PerfSampleWindowSeconds) {
+				return;
+			}
+
+			if (Interlocked.CompareExchange(ref _pinMamePerfWindowStartTicks, nowTicks, startTicks) != startTicks) {
+				return;
+			}
+
+			var callbacks = Interlocked.Exchange(ref _pinMameCallbacksInWindow, 0);
+			var rate = elapsedSeconds > 0.0 ? callbacks / elapsedSeconds : 0.0;
+			Volatile.Write(ref _pinMameCallbackRateHz, (float)rate);
 		}
 	}
 }

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -172,6 +172,7 @@ namespace VisualPinball.Engine.PinMAME
 		private static readonly Color Tint = new(1, 0.18f, 0);
 
 		private readonly Queue<Action> _dispatchQueue = new();
+		private readonly List<Action> _pendingDispatchCallbacks = new();
 		private readonly ConcurrentQueue<CoilEventArgs> _simulationCoilDispatchQueue = new();
 		private int _simulationCoilDispatchQueueSize;
 		private const int MaxSimulationCoilDispatchQueueSize = 8192;
@@ -232,15 +233,20 @@ namespace VisualPinball.Engine.PinMAME
 				return;
 			}
 
+			_pendingDispatchCallbacks.Clear();
+
 			lock (_dispatchQueue) {
 				while (_dispatchQueue.Count > 0) {
-					var callback = _dispatchQueue.Dequeue();
-					try {
-						callback.Invoke();
-					}
-					catch (Exception e) {
-						Logger.Error(e, "[PinMAME] Exception while processing main-thread dispatch callback.");
-					}
+					_pendingDispatchCallbacks.Add(_dispatchQueue.Dequeue());
+				}
+			}
+
+			foreach (var callback in _pendingDispatchCallbacks) {
+				try {
+					callback.Invoke();
+				}
+				catch (Exception e) {
+					Logger.Error(e, "[PinMAME] Exception while processing main-thread dispatch callback.");
 				}
 			}
 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -225,6 +225,7 @@ namespace VisualPinball.Engine.PinMAME
 		private bool _dispatchQueueWarningIssued;
 		private bool _simulationCoilQueueWarningIssued;
 		private bool _simulationCoilQueueDropWarningIssued;
+		private long _solenoidDelayStartTimestampUsec;
 		private const int MaxSimulationCoilDispatchQueueSize = 8192;
 		private const int DispatchQueueWarningThreshold = 512;
 		private const double PerfSampleWindowSeconds = 0.25;
@@ -258,6 +259,8 @@ namespace VisualPinball.Engine.PinMAME
 
 		private bool _toggleSpeed = false;
 		private Keyboard _keyboard;
+
+		private static long TimestampUsec => (Stopwatch.GetTimestamp() * 1_000_000) / Stopwatch.Frequency;
 
 		private static readonly SemaphoreSlim PinMameStartStopGate = new SemaphoreSlim(1, 1);
 		private int _onInitCalled;
@@ -733,7 +736,8 @@ namespace VisualPinball.Engine.PinMAME
 			Logger.Info("[PinMAME] Game started.");
 			_isRunning = true;
 
-			_solenoidDelayStart = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+			_solenoidDelayStartTimestampUsec = TimestampUsec;
+			_solenoidDelayStart = _solenoidDelayStartTimestampUsec / 1000;
 
 			try {
 				SendInitialSwitches();
@@ -1142,7 +1146,7 @@ namespace VisualPinball.Engine.PinMAME
 
 			if (_pinMameIdToCoilIdMapping.ContainsKey(id)) {
 				if (!_solenoidsEnabled) {
-					_solenoidsEnabled = DateTimeOffset.Now.ToUnixTimeMilliseconds() - _solenoidDelayStart >= SolenoidDelay;
+					_solenoidsEnabled = TimestampUsec - _solenoidDelayStartTimestampUsec >= (long)(SolenoidDelay * 1000f);
 
 					if (_solenoidsEnabled) {
 						Logger.Info($"Solenoids enabled, {SolenoidDelay}ms passed");
@@ -1156,7 +1160,9 @@ namespace VisualPinball.Engine.PinMAME
 						_sharedCoilStates[id] = isActive;
 					}
 
-					Logger.Info($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
+					if (Logger.IsDebugEnabled) {
+						Logger.Debug($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
+					}
 					if (ShouldDispatchSimulationCoil(coil.Id)) {
 						_simulationCoilDispatchQueue.Enqueue(new CoilEventArgs(coil.Id, isActive));
 						var simulationCoilQueueSize = Interlocked.Increment(ref _simulationCoilDispatchQueueSize);
@@ -1180,7 +1186,9 @@ namespace VisualPinball.Engine.PinMAME
 					EnqueueMainThreadDispatch(() => OnCoilChanged?.Invoke(this, new CoilEventArgs(coil.Id, isActive)));
 				}
 				else {
-					Logger.Info($"[PinMAME] <= solenoids disabled, coil {coil.Id} : {isActive} | {coil.Description}");
+					if (Logger.IsDebugEnabled) {
+						Logger.Debug($"[PinMAME] <= solenoids disabled, coil {coil.Id} : {isActive} | {coil.Description}");
+					}
 				}
 			}
 			else {

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -175,7 +175,11 @@ namespace VisualPinball.Engine.PinMAME
 		private readonly List<Action> _pendingDispatchCallbacks = new();
 		private readonly ConcurrentQueue<CoilEventArgs> _simulationCoilDispatchQueue = new();
 		private int _simulationCoilDispatchQueueSize;
+		private bool _dispatchQueueWarningIssued;
+		private bool _simulationCoilQueueWarningIssued;
+		private bool _simulationCoilQueueDropWarningIssued;
 		private const int MaxSimulationCoilDispatchQueueSize = 8192;
+		private const int DispatchQueueWarningThreshold = 512;
 		private const double PerfSampleWindowSeconds = 0.25;
 		private long _pinMamePerfWindowStartTicks = Stopwatch.GetTimestamp();
 		private int _pinMameCallbacksInWindow;
@@ -275,6 +279,17 @@ namespace VisualPinball.Engine.PinMAME
 			// 	OnCoilChanged.Invoke(this, new CoilEventArgs("28", true));
 			// 	OnCoilChanged.Invoke(this, new CoilEventArgs("28", false));
 			// }
+		}
+
+		private void EnqueueMainThreadDispatch(Action callback)
+		{
+			lock (_dispatchQueue) {
+				_dispatchQueue.Enqueue(callback);
+				if (!_dispatchQueueWarningIssued && _dispatchQueue.Count >= DispatchQueueWarningThreshold) {
+					_dispatchQueueWarningIssued = true;
+					Logger.Warn($"[PinMAME] Main-thread dispatch queue backlog reached {_dispatchQueue.Count} items.");
+				}
+			}
 		}
 
 		private void OnDestroy()
@@ -611,9 +626,7 @@ namespace VisualPinball.Engine.PinMAME
 				Logger.Error($"[PinMAME] OnGameStarted: {e.Message}");
 			}
 
-			lock (_dispatchQueue) {
-				_dispatchQueue.Enqueue(() => OnStarted?.Invoke(this, EventArgs.Empty));
-			}
+			EnqueueMainThreadDispatch(() => OnStarted?.Invoke(this, EventArgs.Empty));
 		}
 
 		private void OnGameEnded()
@@ -716,21 +729,17 @@ namespace VisualPinball.Engine.PinMAME
 		private void OnDisplayRequested(int index, int displayCount, PinMameDisplayLayout displayLayout)
 		{
 			if (displayLayout.IsDmd) {
-				lock (_dispatchQueue) {
-					_dispatchQueue.Enqueue(() =>
-						OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
-							new DisplayConfig($"{DmdPrefix}{index}", displayLayout.Width, displayLayout.Height))));
-				}
+				EnqueueMainThreadDispatch(() =>
+					OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
+						new DisplayConfig($"{DmdPrefix}{index}", displayLayout.Width, displayLayout.Height))));
 
 				_frameBuffer[index] = new byte[displayLayout.Width * displayLayout.Height];
 				_dmdLevels[index] = displayLayout.Levels;
 
 			} else {
-				lock (_dispatchQueue) {
-					_dispatchQueue.Enqueue(() =>
-						OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
-							new DisplayConfig($"{SegDispPrefix}{index}", displayLayout.Length, 1))));
-				}
+				EnqueueMainThreadDispatch(() =>
+					OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
+						new DisplayConfig($"{SegDispPrefix}{index}", displayLayout.Length, 1))));
 
 				_frameBuffer[index] = new byte[displayLayout.Length * 2];
 				Logger.Info($"[PinMAME] Display {SegDispPrefix}{index} is of type {displayLayout.Type} at {displayLayout.Length} wide.");
@@ -769,21 +778,17 @@ namespace VisualPinball.Engine.PinMAME
 				}
 			}
 
-			lock (_dispatchQueue) {
-				_dispatchQueue.Enqueue(() => OnDisplayUpdateFrame?.Invoke(this,
-					new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
-			}
+			EnqueueMainThreadDispatch(() => OnDisplayUpdateFrame?.Invoke(this,
+				new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
 		}
 
 		private void UpdateSegDisp(int index, PinMameDisplayLayout displayLayout, IntPtr framePtr)
 		{
 			Marshal.Copy(framePtr, _frameBuffer[index], 0, displayLayout.Length * 2);
 
-			lock (_dispatchQueue) {
-				//Logger.Info($"[PinMAME] Seg data ({index}): {BitConverter.ToString(_frameBuffer[index])}" );
-				_dispatchQueue.Enqueue(() => OnDisplayUpdateFrame?.Invoke(this,
-					new DisplayFrameData($"{SegDispPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
-			}
+			//Logger.Info($"[PinMAME] Seg data ({index}): {BitConverter.ToString(_frameBuffer[index])}" );
+			EnqueueMainThreadDispatch(() => OnDisplayUpdateFrame?.Invoke(this,
+				new DisplayFrameData($"{SegDispPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
 		}
 
 		public static DisplayFrameFormat GetDisplayFrameFormat(PinMameDisplayLayout layout)
@@ -998,18 +1003,25 @@ namespace VisualPinball.Engine.PinMAME
 					Logger.Info($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
 					if (IsLowLatencySimulationCoil(coil.Id)) {
 						_simulationCoilDispatchQueue.Enqueue(new CoilEventArgs(coil.Id, isActive));
-						if (Interlocked.Increment(ref _simulationCoilDispatchQueueSize) > MaxSimulationCoilDispatchQueueSize) {
+						var simulationCoilQueueSize = Interlocked.Increment(ref _simulationCoilDispatchQueueSize);
+						if (!_simulationCoilQueueWarningIssued && simulationCoilQueueSize >= MaxSimulationCoilDispatchQueueSize / 2) {
+							_simulationCoilQueueWarningIssued = true;
+							Logger.Warn($"[PinMAME] Simulation coil dispatch backlog reached {simulationCoilQueueSize} items.");
+						}
+						if (simulationCoilQueueSize > MaxSimulationCoilDispatchQueueSize) {
 							if (_simulationCoilDispatchQueue.TryDequeue(out _)) {
 								if (Interlocked.Decrement(ref _simulationCoilDispatchQueueSize) < 0) {
 									Interlocked.Exchange(ref _simulationCoilDispatchQueueSize, 0);
+								}
+								if (!_simulationCoilQueueDropWarningIssued) {
+									_simulationCoilQueueDropWarningIssued = true;
+									Logger.Warn($"[PinMAME] Simulation coil dispatch queue exceeded {MaxSimulationCoilDispatchQueueSize} items. Dropping oldest coil callbacks.");
 								}
 							}
 						}
 					}
 
-					lock (_dispatchQueue) {
-						_dispatchQueue.Enqueue(() => OnCoilChanged?.Invoke(this, new CoilEventArgs(coil.Id, isActive)));
-					}
+					EnqueueMainThreadDispatch(() => OnCoilChanged?.Invoke(this, new CoilEventArgs(coil.Id, isActive)));
 				}
 				else {
 					Logger.Info($"[PinMAME] <= solenoids disabled, coil {coil.Id} : {isActive} | {coil.Description}");
@@ -1109,9 +1121,7 @@ namespace VisualPinball.Engine.PinMAME
 		private void OnMechUpdated(int mechNo, PinMameMechInfo mechInfo)
 		{
 			if (_registeredMechs.ContainsKey(mechNo)) {
-				lock (_dispatchQueue) {
-					_dispatchQueue.Enqueue(() => _registeredMechs[mechNo].UpdateMech(mechInfo));
-				}
+				EnqueueMainThreadDispatch(() => _registeredMechs[mechNo].UpdateMech(mechInfo));
 
 			} else {
 				Logger.Info($"[PinMAME] <= mech updated: mechNo={mechNo}, mechInfo={mechInfo}");

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -1023,7 +1023,7 @@ namespace VisualPinball.Engine.PinMAME
 
 				if (_solenoidsEnabled) {
 					Logger.Info($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
-					if (IsLowLatencySimulationCoil(coil.Id)) {
+					if (ShouldDispatchSimulationCoil(coil.Id)) {
 						_simulationCoilDispatchQueue.Enqueue(new CoilEventArgs(coil.Id, isActive));
 						var simulationCoilQueueSize = Interlocked.Increment(ref _simulationCoilDispatchQueueSize);
 						if (!_simulationCoilQueueWarningIssued && simulationCoilQueueSize >= MaxSimulationCoilDispatchQueueSize / 2) {
@@ -1185,10 +1185,11 @@ namespace VisualPinball.Engine.PinMAME
 			return 0;
 		}
 
-		private static bool IsLowLatencySimulationCoil(string coilId)
+		private bool ShouldDispatchSimulationCoil(string coilId)
 		{
 			return !string.IsNullOrEmpty(coilId)
-				&& coilId.StartsWith("c_flipper", StringComparison.OrdinalIgnoreCase);
+				&& _player != null
+				&& _player.SupportsSimulationThreadCoilDispatch(coilId);
 		}
 
 		private void MarkPinMameCallbackActivity()

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -41,7 +41,7 @@ namespace VisualPinball.Engine.PinMAME
 	[DisallowMultipleComponent]
 	[RequireComponent(typeof(AudioSource))]
 	[AddComponentMenu("Pinball/Gamelogic Engine/PinMAME")]
-	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence, IGamelogicCoilOutputFeed, IGamelogicSharedStateWriter, IGamelogicPerformanceStats
+	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence, IGamelogicCoilOutputFeed, IGamelogicSharedStateWriter, IGamelogicSharedStateApplier, IGamelogicPerformanceStats
 	{
 		public string Name { get; } = "PinMAME Gamelogic Engine";
 		public GamelogicInputDispatchMode SwitchDispatchMode => GamelogicInputDispatchMode.SimulationThread;
@@ -148,6 +148,41 @@ namespace VisualPinball.Engine.PinMAME
 			}
 		}
 
+		public void ApplySharedState(in SimulationState.Snapshot snapshot)
+		{
+			if (_player == null) {
+				return;
+			}
+
+			_sharedLampPlaybackActive = true;
+
+			for (var i = 0; i < snapshot.LampCount; i++) {
+				var lamp = snapshot.LampStates[i];
+				if (!_pinMameIdToLampIdMapping.TryGetValue(lamp.Id, out var lampId)) {
+					continue;
+				}
+				if (_lastAppliedLampStates.TryGetValue(lamp.Id, out var currentValue) && currentValue == lamp.Value) {
+					continue;
+				}
+
+				_lastAppliedLampStates[lamp.Id] = lamp.Value;
+				_player.SetLamp(lampId, lamp.Value, LampSource.Lamp);
+			}
+
+			for (var i = 0; i < snapshot.GICount; i++) {
+				var gi = snapshot.GIStates[i];
+				if (!_pinMameIdToLampIdMapping.TryGetValue(gi.Id, out var giId)) {
+					continue;
+				}
+				if (_lastAppliedGiStates.TryGetValue(gi.Id, out var currentValue) && currentValue == gi.Value) {
+					continue;
+				}
+
+				_lastAppliedGiStates[gi.Id] = gi.Value;
+				_player.SetLamp(giId, gi.Value, LampSource.GI);
+			}
+		}
+
 		#endregion
 
 		#region Internals
@@ -199,6 +234,9 @@ namespace VisualPinball.Engine.PinMAME
 		private readonly Dictionary<int, bool> _sharedCoilStates = new();
 		private readonly Dictionary<int, float> _sharedLampStates = new();
 		private readonly Dictionary<int, float> _sharedGiStates = new();
+		private readonly Dictionary<int, float> _lastAppliedLampStates = new();
+		private readonly Dictionary<int, float> _lastAppliedGiStates = new();
+		private bool _sharedLampPlaybackActive;
 		private readonly Queue<float[]> _audioQueue = new();
 
 		private int _audioFilterChannels;
@@ -275,7 +313,7 @@ namespace VisualPinball.Engine.PinMAME
 				lock (_outputStateLock) {
 					_sharedLampStates[changedLamp.Id] = changedLamp.Value;
 				}
-				if (_pinMameIdToLampIdMapping.ContainsKey(changedLamp.Id)) {
+				if (!_sharedLampPlaybackActive && _pinMameIdToLampIdMapping.ContainsKey(changedLamp.Id)) {
 					//Logger.Info($"[PinMAME] <= lamp {changedLamp.Id}: {changedLamp.Value}");
 					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[_pinMameIdToLampIdMapping[changedLamp.Id]].Id, changedLamp.Value));
 				}
@@ -287,7 +325,7 @@ namespace VisualPinball.Engine.PinMAME
 				lock (_outputStateLock) {
 					_sharedGiStates[changedGi.Id] = changedGi.Value;
 				}
-				if (_pinMameIdToLampIdMapping.ContainsKey(changedGi.Id)) {
+				if (!_sharedLampPlaybackActive && _pinMameIdToLampIdMapping.ContainsKey(changedGi.Id)) {
 					//Logger.Info($"[PinMAME] <= gi {changedGi.Id}: {changedGi.Value}");
 					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[_pinMameIdToLampIdMapping[changedGi.Id]].Id, changedGi.Value, LampSource.GI));
 				} /*else {
@@ -395,6 +433,9 @@ namespace VisualPinball.Engine.PinMAME
 				_sharedLampStates.Clear();
 				_sharedGiStates.Clear();
 			}
+			_lastAppliedLampStates.Clear();
+			_lastAppliedGiStates.Clear();
+			_sharedLampPlaybackActive = false;
 		}
 
 		private void OnDisable()
@@ -723,6 +764,9 @@ namespace VisualPinball.Engine.PinMAME
 				_sharedLampStates.Clear();
 				_sharedGiStates.Clear();
 			}
+			_lastAppliedLampStates.Clear();
+			_lastAppliedGiStates.Clear();
+			_sharedLampPlaybackActive = false;
 		}
 
 		private void UpdateCaches()

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -211,10 +211,10 @@ namespace VisualPinball.Engine.PinMAME
 		private volatile bool _isRunning;
 		private int _numMechs;
 		private Dictionary<int, byte[]> _frameBuffer = new();
-		private Dictionary<int, Dictionary<byte, byte>> _dmdLevels = new();
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 		private static readonly Color Tint = new(1, 0.18f, 0);
+		private static readonly Color UnlitTint = new(Tint.r * 0.18f, Tint.g * 0.18f, Tint.b * 0.18f, 1f);
 
 		private readonly Queue<Action> _dispatchQueue = new();
 		private readonly List<Action> _pendingDispatchCallbacks = new();
@@ -430,7 +430,6 @@ namespace VisualPinball.Engine.PinMAME
 				_pinMame.IsKeyPressed -= IsKeyPressed;
 			}
 			_frameBuffer.Clear();
-			_dmdLevels.Clear();
 			lock (_outputStateLock) {
 				_sharedCoilStates.Clear();
 				_sharedLampStates.Clear();
@@ -861,11 +860,10 @@ namespace VisualPinball.Engine.PinMAME
 			if (displayLayout.IsDmd) {
 				EnqueueMainThreadDispatch(() =>
 					OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
-						new DisplayConfig($"{DmdPrefix}{index}", displayLayout.Width, displayLayout.Height))));
+						new DisplayConfig($"{DmdPrefix}{index}", displayLayout.Width, displayLayout.Height, false, Tint, UnlitTint))));
 
 				lock (_displayStateLock) {
 					_frameBuffer[index] = new byte[displayLayout.Width * displayLayout.Height];
-					_dmdLevels[index] = displayLayout.Levels;
 				}
 
 			} else {
@@ -895,31 +893,14 @@ namespace VisualPinball.Engine.PinMAME
 		private void UpdateDmd(int index, PinMameDisplayLayout displayLayout, IntPtr framePtr)
 		{
 			byte[] frameBuffer;
-			Dictionary<byte, byte> levels;
 			lock (_displayStateLock) {
 				if (!_frameBuffer.TryGetValue(index, out frameBuffer)) {
 					Logger.Warn($"[PinMAME] Dropping DMD frame for unknown index {index} (layout: {displayLayout}).");
 					return;
 				}
-				if (!_dmdLevels.TryGetValue(index, out levels) || levels == null) {
-					Logger.Warn($"[PinMAME] Dropping DMD frame for index {index} because display levels are not initialized yet.");
-					return;
-				}
 			}
 
-			unsafe {
-				var ptr = (byte*) framePtr;
-				for (var y = 0; y < displayLayout.Height; y++) {
-					for (var x = 0; x < displayLayout.Width; x++) {
-						var pos = y * displayLayout.Width + x;
-						if (!levels.ContainsKey(ptr[pos])) {
-							Logger.Error($"Display {index}: Provided levels ({BitConverter.ToString(levels.Keys.ToArray())}) don't contain level {BitConverter.ToString(new[] {ptr[pos]})}.");
-							levels[ptr[pos]] = 0x4;
-						}
-						frameBuffer[pos] = levels[ptr[pos]];
-					}
-				}
-			}
+			Marshal.Copy(framePtr, frameBuffer, 0, frameBuffer.Length);
 
 			EnqueueMainThreadDispatch(() => OnDisplayUpdateFrame?.Invoke(this,
 				new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), frameBuffer)));
@@ -945,7 +926,7 @@ namespace VisualPinball.Engine.PinMAME
 		public static DisplayFrameFormat GetDisplayFrameFormat(PinMameDisplayLayout layout)
 		{
 			if (layout.IsDmd) {
-				return layout.Depth == 4 ? DisplayFrameFormat.Dmd4 : DisplayFrameFormat.Dmd2;
+				return DisplayFrameFormat.Dmd8;
 			}
 
 			switch (layout.Type) {

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -32,6 +32,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using VisualPinball.Engine.Game.Engines;
 using VisualPinball.Unity;
+using VisualPinball.Unity.Simulation;
 using Logger = NLog.Logger;
 
 namespace VisualPinball.Engine.PinMAME
@@ -40,7 +41,7 @@ namespace VisualPinball.Engine.PinMAME
 	[DisallowMultipleComponent]
 	[RequireComponent(typeof(AudioSource))]
 	[AddComponentMenu("Pinball/Gamelogic Engine/PinMAME")]
-	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence, IGamelogicCoilOutputFeed, IGamelogicPerformanceStats
+	public class PinMameGamelogicEngine : MonoBehaviour, IGamelogicEngine, IGamelogicInputThreading, IGamelogicTimeFence, IGamelogicCoilOutputFeed, IGamelogicSharedStateWriter, IGamelogicPerformanceStats
 	{
 		public string Name { get; } = "PinMAME Gamelogic Engine";
 		public GamelogicInputDispatchMode SwitchDispatchMode => GamelogicInputDispatchMode.SimulationThread;
@@ -138,6 +139,15 @@ namespace VisualPinball.Engine.PinMAME
 			return true;
 		}
 
+		public void WriteSharedState(ref SimulationState.Snapshot snapshot)
+		{
+			lock (_outputStateLock) {
+				snapshot.CoilCount = CopyCoilStates(ref snapshot);
+				snapshot.LampCount = CopyLampStates(ref snapshot);
+				snapshot.GICount = CopyGiStates(ref snapshot);
+			}
+		}
+
 		#endregion
 
 		#region Internals
@@ -174,6 +184,7 @@ namespace VisualPinball.Engine.PinMAME
 		private readonly Queue<Action> _dispatchQueue = new();
 		private readonly List<Action> _pendingDispatchCallbacks = new();
 		private readonly object _displayStateLock = new();
+		private readonly object _outputStateLock = new();
 		private readonly ConcurrentQueue<CoilEventArgs> _simulationCoilDispatchQueue = new();
 		private int _simulationCoilDispatchQueueSize;
 		private bool _dispatchQueueWarningIssued;
@@ -185,6 +196,9 @@ namespace VisualPinball.Engine.PinMAME
 		private long _pinMamePerfWindowStartTicks = Stopwatch.GetTimestamp();
 		private int _pinMameCallbacksInWindow;
 		private float _pinMameCallbackRateHz;
+		private readonly Dictionary<int, bool> _sharedCoilStates = new();
+		private readonly Dictionary<int, float> _sharedLampStates = new();
+		private readonly Dictionary<int, float> _sharedGiStates = new();
 		private readonly Queue<float[]> _audioQueue = new();
 
 		private int _audioFilterChannels;
@@ -258,6 +272,9 @@ namespace VisualPinball.Engine.PinMAME
 			// lamps
 			_pinMame.GetChangedLamps(_changedLamps);
 			foreach (var changedLamp in _changedLamps) {
+				lock (_outputStateLock) {
+					_sharedLampStates[changedLamp.Id] = changedLamp.Value;
+				}
 				if (_pinMameIdToLampIdMapping.ContainsKey(changedLamp.Id)) {
 					//Logger.Info($"[PinMAME] <= lamp {changedLamp.Id}: {changedLamp.Value}");
 					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[_pinMameIdToLampIdMapping[changedLamp.Id]].Id, changedLamp.Value));
@@ -267,6 +284,9 @@ namespace VisualPinball.Engine.PinMAME
 			// gi
 			_pinMame.GetChangedGIs(_changedGIs);
 			foreach (var changedGi in _changedGIs) {
+				lock (_outputStateLock) {
+					_sharedGiStates[changedGi.Id] = changedGi.Value;
+				}
 				if (_pinMameIdToLampIdMapping.ContainsKey(changedGi.Id)) {
 					//Logger.Info($"[PinMAME] <= gi {changedGi.Id}: {changedGi.Value}");
 					OnLampChanged?.Invoke(this, new LampEventArgs(_lamps[_pinMameIdToLampIdMapping[changedGi.Id]].Id, changedGi.Value, LampSource.GI));
@@ -291,6 +311,57 @@ namespace VisualPinball.Engine.PinMAME
 					Logger.Warn($"[PinMAME] Main-thread dispatch queue backlog reached {_dispatchQueue.Count} items.");
 				}
 			}
+		}
+
+		private int CopyCoilStates(ref SimulationState.Snapshot snapshot)
+		{
+			var index = 0;
+			foreach (var entry in _sharedCoilStates) {
+				if (index >= snapshot.CoilStates.Length) {
+					break;
+				}
+
+				snapshot.CoilStates[index++] = new SimulationState.CoilState {
+					Id = entry.Key,
+					IsActive = entry.Value ? (byte)1 : (byte)0,
+				};
+			}
+
+			return index;
+		}
+
+		private int CopyLampStates(ref SimulationState.Snapshot snapshot)
+		{
+			var index = 0;
+			foreach (var entry in _sharedLampStates) {
+				if (index >= snapshot.LampStates.Length) {
+					break;
+				}
+
+				snapshot.LampStates[index++] = new SimulationState.LampState {
+					Id = entry.Key,
+					Value = entry.Value,
+				};
+			}
+
+			return index;
+		}
+
+		private int CopyGiStates(ref SimulationState.Snapshot snapshot)
+		{
+			var index = 0;
+			foreach (var entry in _sharedGiStates) {
+				if (index >= snapshot.GIStates.Length) {
+					break;
+				}
+
+				snapshot.GIStates[index++] = new SimulationState.GIState {
+					Id = entry.Key,
+					Value = entry.Value,
+				};
+			}
+
+			return index;
 		}
 
 		private void OnDestroy()
@@ -319,6 +390,11 @@ namespace VisualPinball.Engine.PinMAME
 			}
 			_frameBuffer.Clear();
 			_dmdLevels.Clear();
+			lock (_outputStateLock) {
+				_sharedCoilStates.Clear();
+				_sharedLampStates.Clear();
+				_sharedGiStates.Clear();
+			}
 		}
 
 		private void OnDisable()
@@ -641,6 +717,11 @@ namespace VisualPinball.Engine.PinMAME
 				if (Interlocked.Decrement(ref _simulationCoilDispatchQueueSize) < 0) {
 					Interlocked.Exchange(ref _simulationCoilDispatchQueueSize, 0);
 				}
+			}
+			lock (_outputStateLock) {
+				_sharedCoilStates.Clear();
+				_sharedLampStates.Clear();
+				_sharedGiStates.Clear();
 			}
 		}
 
@@ -998,6 +1079,11 @@ namespace VisualPinball.Engine.PinMAME
 
 		public void SetCoil(string n, bool value)
 		{
+			if (int.TryParse(n, out var coilId)) {
+				lock (_outputStateLock) {
+					_sharedCoilStates[coilId] = value;
+				}
+			}
 			OnCoilChanged?.Invoke(this, new CoilEventArgs(n, value));
 		}
 
@@ -1022,6 +1108,10 @@ namespace VisualPinball.Engine.PinMAME
 				var coil = _coils[_pinMameIdToCoilIdMapping[id]];
 
 				if (_solenoidsEnabled) {
+					lock (_outputStateLock) {
+						_sharedCoilStates[id] = isActive;
+					}
+
 					Logger.Info($"[PinMAME] <= coil {coil.Id} : {isActive} | {coil.Description}");
 					if (ShouldDispatchSimulationCoil(coil.Id)) {
 						_simulationCoilDispatchQueue.Enqueue(new CoilEventArgs(coil.Id, isActive));
@@ -1060,6 +1150,15 @@ namespace VisualPinball.Engine.PinMAME
 
 		public void SetLamp(string id, float value, bool isCoil = false, LampSource source = LampSource.Lamp)
 		{
+			if (int.TryParse(id, out var lampId)) {
+				lock (_outputStateLock) {
+					if (source == LampSource.GI) {
+						_sharedGiStates[lampId] = value;
+					} else {
+						_sharedLampStates[lampId] = value;
+					}
+				}
+			}
 			OnLampChanged?.Invoke(this, new LampEventArgs(id, value, isCoil, source));
 		}
 

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameGamelogicEngine.cs
@@ -173,6 +173,7 @@ namespace VisualPinball.Engine.PinMAME
 
 		private readonly Queue<Action> _dispatchQueue = new();
 		private readonly List<Action> _pendingDispatchCallbacks = new();
+		private readonly object _displayStateLock = new();
 		private readonly ConcurrentQueue<CoilEventArgs> _simulationCoilDispatchQueue = new();
 		private int _simulationCoilDispatchQueueSize;
 		private bool _dispatchQueueWarningIssued;
@@ -733,15 +734,19 @@ namespace VisualPinball.Engine.PinMAME
 					OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
 						new DisplayConfig($"{DmdPrefix}{index}", displayLayout.Width, displayLayout.Height))));
 
-				_frameBuffer[index] = new byte[displayLayout.Width * displayLayout.Height];
-				_dmdLevels[index] = displayLayout.Levels;
+				lock (_displayStateLock) {
+					_frameBuffer[index] = new byte[displayLayout.Width * displayLayout.Height];
+					_dmdLevels[index] = displayLayout.Levels;
+				}
 
 			} else {
 				EnqueueMainThreadDispatch(() =>
 					OnDisplaysRequested?.Invoke(this, new RequestedDisplays(
 						new DisplayConfig($"{SegDispPrefix}{index}", displayLayout.Length, 1))));
 
-				_frameBuffer[index] = new byte[displayLayout.Length * 2];
+				lock (_displayStateLock) {
+					_frameBuffer[index] = new byte[displayLayout.Length * 2];
+				}
 				Logger.Info($"[PinMAME] Display {SegDispPrefix}{index} is of type {displayLayout.Type} at {displayLayout.Length} wide.");
 			}
 		}
@@ -750,10 +755,6 @@ namespace VisualPinball.Engine.PinMAME
 		{
 			MarkPinMameCallbackActivity();
 
-			if (!_frameBuffer.ContainsKey(index)) {
-				Logger.Warn($"[PinMAME] Dropping display frame for unknown index {index} (layout: {displayLayout}).");
-				return;
-			}
 			if (displayLayout.IsDmd) {
 				UpdateDmd(index, displayLayout, framePtr);
 
@@ -764,31 +765,52 @@ namespace VisualPinball.Engine.PinMAME
 
 		private void UpdateDmd(int index, PinMameDisplayLayout displayLayout, IntPtr framePtr)
 		{
+			byte[] frameBuffer;
+			Dictionary<byte, byte> levels;
+			lock (_displayStateLock) {
+				if (!_frameBuffer.TryGetValue(index, out frameBuffer)) {
+					Logger.Warn($"[PinMAME] Dropping DMD frame for unknown index {index} (layout: {displayLayout}).");
+					return;
+				}
+				if (!_dmdLevels.TryGetValue(index, out levels) || levels == null) {
+					Logger.Warn($"[PinMAME] Dropping DMD frame for index {index} because display levels are not initialized yet.");
+					return;
+				}
+			}
+
 			unsafe {
 				var ptr = (byte*) framePtr;
 				for (var y = 0; y < displayLayout.Height; y++) {
 					for (var x = 0; x < displayLayout.Width; x++) {
 						var pos = y * displayLayout.Width + x;
-						if (!_dmdLevels[index].ContainsKey(ptr[pos])) {
-							Logger.Error($"Display {index}: Provided levels ({BitConverter.ToString(_dmdLevels[index].Keys.ToArray())}) don't contain level {BitConverter.ToString(new[] {ptr[pos]})}.");
-							_dmdLevels[index][ptr[pos]] = 0x4;
+						if (!levels.ContainsKey(ptr[pos])) {
+							Logger.Error($"Display {index}: Provided levels ({BitConverter.ToString(levels.Keys.ToArray())}) don't contain level {BitConverter.ToString(new[] {ptr[pos]})}.");
+							levels[ptr[pos]] = 0x4;
 						}
-						_frameBuffer[index][pos] = _dmdLevels[index][ptr[pos]];
+						frameBuffer[pos] = levels[ptr[pos]];
 					}
 				}
 			}
 
 			EnqueueMainThreadDispatch(() => OnDisplayUpdateFrame?.Invoke(this,
-				new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
+				new DisplayFrameData($"{DmdPrefix}{index}", GetDisplayFrameFormat(displayLayout), frameBuffer)));
 		}
 
 		private void UpdateSegDisp(int index, PinMameDisplayLayout displayLayout, IntPtr framePtr)
 		{
-			Marshal.Copy(framePtr, _frameBuffer[index], 0, displayLayout.Length * 2);
+			byte[] frameBuffer;
+			lock (_displayStateLock) {
+				if (!_frameBuffer.TryGetValue(index, out frameBuffer)) {
+					Logger.Warn($"[PinMAME] Dropping segmented display frame for unknown index {index} (layout: {displayLayout}).");
+					return;
+				}
+			}
+
+			Marshal.Copy(framePtr, frameBuffer, 0, displayLayout.Length * 2);
 
 			//Logger.Info($"[PinMAME] Seg data ({index}): {BitConverter.ToString(_frameBuffer[index])}" );
 			EnqueueMainThreadDispatch(() => OnDisplayUpdateFrame?.Invoke(this,
-				new DisplayFrameData($"{SegDispPrefix}{index}", GetDisplayFrameFormat(displayLayout), _frameBuffer[index])));
+				new DisplayFrameData($"{SegDispPrefix}{index}", GetDisplayFrameFormat(displayLayout), frameBuffer)));
 		}
 
 		public static DisplayFrameFormat GetDisplayFrameFormat(PinMameDisplayLayout layout)

--- a/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameMechComponent.cs
+++ b/VisualPinball.Engine.PinMAME.Unity/Runtime/PinMameMechComponent.cs
@@ -135,7 +135,7 @@ namespace VisualPinball.Engine.PinMAME
 			foreach (var mark in Marks) {
 				var switchMapping = switchMappings.FirstOrDefault(sm => ReferenceEquals(sm.Device, this) && sm.DeviceItem == mark.SwitchId);
 				if (switchMapping == null) {
-					Logger.Error($"Switch \"{mark.Name}\" for mech {name} is not mapped in the switch manager, ignoring.");
+					Logger.Error($"Switch \"{mark.Name}\" for mech {_cachedName} is not mapped in the switch manager, ignoring.");
 					continue;
 				}
 
@@ -160,6 +160,7 @@ namespace VisualPinball.Engine.PinMAME
 		}
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		private string _cachedName = "<unnamed-mech>";
 
 		private const string EventNameSpeed = "Mech Speed";
 		private const string EventNamePosition = "Mech Position";
@@ -225,6 +226,7 @@ namespace VisualPinball.Engine.PinMAME
 
 		private void Awake()
 		{
+			_cachedName = gameObject.name;
 			_gle = GetComponentInParent<PinMameGamelogicEngine>();
 			if (_gle && enabled) {
 				_gle.RegisterMech(this);

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -5,7 +5,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>9.0</LangVersion>
-    <PinMameVersion>1.0.0</PinMameVersion>
+    <PinMameVersion>1.0.1</PinMameVersion>
     <PinMameNativeVersion>3.7.0-beta1</PinMameNativeVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">

--- a/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
+++ b/VisualPinball.Engine.PinMAME/VisualPinball.Engine.PinMAME.csproj
@@ -5,7 +5,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>9.0</LangVersion>
-    <PinMameVersion>1.0.1</PinMameVersion>
+    <PinMameVersion>1.0.2</PinMameVersion>
     <PinMameNativeVersion>3.7.0-beta1</PinMameNativeVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">


### PR DESCRIPTION
This PR stabilizes the PinMAME Unity integration around play mode lifecycle, cross-thread event dispatch, and shared-state handoff with the simulation thread. It also updates the PinMAME .NET dependency to 1.0.2, which uses the lastest PinMAME 3.7 beta.

### Lifecycle and shutdown safety
- Added editor play mode lifecycle hook (`PinMamePlayModeLifecycle`) to coordinate deterministic PinMAME shutdown on play mode exit/editor quit.
- Hardened `PinMameGamelogicEngine` init/stop flow with start/stop gating and defensive unsubscribe/cleanup paths.
- Added `StopForPlayModeExit()` and improved `OnDisable`/`OnDestroy`/`OnApplicationQuit` handling to avoid stale callbacks and overlapping sessions.

### Threading and performance instrumentation
- Added simulation-thread-facing interfaces:
  - `IGamelogicInputThreading`
  - `IGamelogicTimeFence`
  - `IGamelogicCoilOutputFeed`
  - `IGamelogicSharedStateWriter`
  - `IGamelogicSharedStateApplier`
  - `IGamelogicPerformanceStats`
- Added bounded/instrumented coil dispatch queue for simulation-thread consumption (`TryDequeueCoilEvent`), including backlog/drop warnings.
- Added callback-rate sampling and `TryGetPerformanceStats`.

### Shared state publication / application
- Added shared state snapshots for coils/lamps/GI (`WriteSharedState` + `ApplySharedState`) with lock-protected state caches.
- Added de-duplication when applying lamp/GI state to avoid redundant updates.

### Display / output handling improvements
- Reworked DMD frame copy path to direct byte copy and moved dispatch through main-thread queue wrapper.
- Switched DMD frame format reporting to `DisplayFrameFormat.Dmd8`.
- Added safer handling when display frames arrive before display buffers are registered.

### Mech and misc fixes
- Fixed mech registration to use 1-based IDs and improved mech slot/max diagnostics.
- Cached mech name in `PinMameMechComponent` for clearer mapping error logs.
- Reduced hot-path logging in callback-heavy code paths.

## Testing
- No automated test run was performed as part of this PR draft.
- Recommended validation:
  - Enter/exit play mode repeatedly with domain reload on/off.
  - Verify ROM start/stop reliability across sessions.
  - Verify DMD/segment updates and lamp/GI behavior.
  - Verify mech registration and coil dispatch behavior under load.
